### PR TITLE
Fix typo in betting prompt

### DIFF
--- a/main.c
+++ b/main.c
@@ -521,7 +521,7 @@ int8_t betting_phase(Player* player, Player* dealer)
         else if(bet < 10)
             printf("Minimum bet is 10. Please enter a valid bet: ");
         else if(bet % 10 != 0)
-            printf("The best must be multiplication of 10. Please enter a valid bet: ");
+            printf("The bet must be a multiple of 10. Please enter a valid bet: ");
         scanf("%hu", &bet);
     }
     player->cash -= bet;


### PR DESCRIPTION
## Summary
- fix typo in betting prompt string in `betting_phase`

## Testing
- `git diff -U0 main.c`


------
https://chatgpt.com/codex/tasks/task_e_6842c81ea15c8333a6307d95a6b47174